### PR TITLE
Add error ignoring to ParseReportFeature

### DIFF
--- a/TrailBot/WtaDataProvider.cs
+++ b/TrailBot/WtaDataProvider.cs
@@ -323,11 +323,18 @@ namespace CascadePass.TrailBot
         private List<string> ParseReportFeature(IWebDriver webDriver)
         {
             List<string> found = new();
-            IWebElement tripHighlights = webDriver.FindElement(By.ClassName("wta-icon-list"));
 
-            foreach (var ele in tripHighlights?.FindElements(By.ClassName("wta-icon")))
+            try
             {
-                found.Add(ele.Text);
+                IWebElement tripHighlights = webDriver.FindElement(By.ClassName("wta-icon-list"));
+
+                foreach (var ele in tripHighlights?.FindElements(By.ClassName("wta-icon")))
+                {
+                    found.Add(ele.Text);
+                }
+            }
+            catch (NoSuchElementException)
+            {
             }
 
             return found;


### PR DESCRIPTION
_This change should probably be made to other methods that collect info from the DOM.  In the meantime, I've only ever seen a problem here and think everything else is required._

Trip Report **features** can legitimately not be present in the document.  Not every report is about a hike that had wildflowers etc.  There isn't a way to test the DOM for the existence of certain elements, so I use a try and catch NoSuchElementException.