### PR TITLE
Add Settings.DebugMode property

### DIFF
--- a/TrailBot.UI.Tests/SettingsTests.cs
+++ b/TrailBot.UI.Tests/SettingsTests.cs
@@ -33,7 +33,7 @@ namespace CascadePass.TrailBot.UI.Tests
         #region get/set access same value
 
         [TestMethod]
-        public void XmlFolder()
+        public void XmlFolder_GetSetAccessSameValue()
         {
             string value = Guid.NewGuid().ToString();
             Settings settings = new();
@@ -43,7 +43,7 @@ namespace CascadePass.TrailBot.UI.Tests
         }
 
         [TestMethod]
-        public void ShowPreviewPane()
+        public void ShowPreviewPane_GetSetAccessSameValue()
         {
             Settings settings = new();
 
@@ -55,13 +55,23 @@ namespace CascadePass.TrailBot.UI.Tests
         }
 
         [TestMethod]
-        public void IndexFilename()
+        public void IndexFilename_GetSetAccessSameValue()
         {
             string value = Guid.NewGuid().ToString();
             Settings settings = new();
 
             settings.IndexFilename = value;
             Assert.IsTrue(string.Equals(settings.IndexFilename, value, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public void DebugMode_GetSetAccessSameValue()
+        {
+            Settings settings = new();
+
+            bool value = !settings.DebugMode;
+            settings.DebugMode = value;
+            Assert.AreEqual(settings.DebugMode, value);
         }
 
         #endregion
@@ -94,6 +104,15 @@ namespace CascadePass.TrailBot.UI.Tests
             Settings settings = new();
 
             settings.IndexFilename = value;
+            Assert.IsTrue(settings.IsDirty);
+        }
+
+        [TestMethod]
+        public void DebugMode_Makes_IsDirty_True()
+        {
+            Settings settings = new();
+
+            settings.DebugMode = !settings.DebugMode;
             Assert.IsTrue(settings.IsDirty);
         }
 

--- a/TrailBot.UI/Settings.cs
+++ b/TrailBot.UI/Settings.cs
@@ -7,7 +7,7 @@ namespace CascadePass.TrailBot.UI
     public class Settings : ObservableObject
     {
         private string xmlFolder, indexFilename;
-        private bool showPreviewPane, isDirty;
+        private bool showPreviewPane, isDirty, debugMode;
 
         #region Properties
 
@@ -51,6 +51,19 @@ namespace CascadePass.TrailBot.UI
                 {
                     this.showPreviewPane = value;
                     this.OnPropertyChanged(nameof(this.ShowPreviewPane));
+                }
+            }
+        }
+
+        public bool DebugMode
+        {
+            get => this.debugMode;
+            set
+            {
+                if (this.debugMode != value)
+                {
+                    this.debugMode = value;
+                    this.OnPropertyChanged(nameof(this.DebugMode));
                 }
             }
         }

--- a/TrailBot.UI/UIcore/StatusStrip.xaml
+++ b/TrailBot.UI/UIcore/StatusStrip.xaml
@@ -35,39 +35,39 @@
                     <Border BorderBrush="LightGray" BorderThickness="0,0,.5,0" Padding="5,0,5,0">
                         <StackPanel Orientation="Horizontal">
                             <Image
-                    Height="16" Width="16" Margin="0,0,3,0"
-                    VerticalAlignment="Center" HorizontalAlignment="Center"
-                    Source="pack://application:,,,/Images/FastLineChart.png" />
+                                Height="16" Width="16" Margin="0,0,3,0"
+                                VerticalAlignment="Center" HorizontalAlignment="Center"
+                                Source="pack://application:,,,/Images/FastLineChart.png" />
 
                             <TextBlock                
-                    ToolTip="Matched TRs"
-                    Foreground="OrangeRed"
-                    VerticalAlignment="Center"
-                    FontWeight="Bold">
+                                ToolTip="Matched TRs"
+                                Foreground="OrangeRed"
+                                VerticalAlignment="Center"
+                                FontWeight="Bold">
                     
-                    <Run Text="{Binding MatchedCount, Mode=OneWay, StringFormat='0,0.'}" />
+                                <Run Text="{Binding MatchedCount, Mode=OneWay, StringFormat='0,0.'}" />
                             </TextBlock>
 
                             <TextBlock Text="/" Margin="1,0,1,0" />
 
                             <TextBlock                
-                    ToolTip="Pending TRs to read"
-                    Foreground="Blue"
-                    VerticalAlignment="Center"
-                    FontWeight="Bold">
+                                ToolTip="Pending TRs to read"
+                                Foreground="Blue"
+                                VerticalAlignment="Center"
+                                FontWeight="Bold">
                     
-                    <Run Text="{Binding PendingCount, Mode=OneWay, StringFormat='0,0.'}" />
+                                <Run Text="{Binding PendingCount, Mode=OneWay, StringFormat='0,0.'}" />
                             </TextBlock>
 
                             <TextBlock Text="/" Margin="1,0,1,0" />
 
                             <TextBlock                
-                    ToolTip="TRs read"
-                    Foreground="Purple"
-                    VerticalAlignment="Center"
-                    FontWeight="Bold">
+                                ToolTip="TRs read"
+                                Foreground="Purple"
+                                VerticalAlignment="Center"
+                                FontWeight="Bold">
                     
-                    <Run Text="{Binding TripReportsRead, Mode=OneWay, StringFormat='0,0.'}" />
+                                <Run Text="{Binding TripReportsRead, Mode=OneWay, StringFormat='0,0.'}" />
                             </TextBlock>
                         </StackPanel>
                     </Border>
@@ -77,6 +77,7 @@
 
                 <TextBlock
                     ToolTip="Private bytes (RAM) allocated to Trip Report Reader"
+                    Visibility="{Binding ShowMemoryInfo, Converter={StaticResource bool2vis}}"
                     Foreground="Red"
                     Margin="5,0,5,0">
 

--- a/TrailBot.UI/UIcore/StatusStripViewModel.cs
+++ b/TrailBot.UI/UIcore/StatusStripViewModel.cs
@@ -125,6 +125,9 @@ namespace CascadePass.TrailBot.UI
             }
         }
 
+        //TODO: Create local settings reference, subscribe to changes, raise notifications for this
+        public bool ShowMemoryInfo => ApplicationData.Settings.DebugMode;
+
         public string StatusText
         {
             get => this.statusText;


### PR DESCRIPTION
Create property, add tests, update status strip to only show memory info when DebugMode is true.  (There is currently no way to turn it on except by hand editing the xml.)

Settings page has not been updated, it needs an overhaul and will be dealt with separately.