### PR TITLE
Count matching terms

### DIFF
--- a/TrailBot.Tests/MatchedTripReportTests.cs
+++ b/TrailBot.Tests/MatchedTripReportTests.cs
@@ -196,5 +196,23 @@ namespace CascadePass.TrailBot.Tests
         }
 
         #endregion
+
+        #region GetMatchCounts
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GetMatchCounts_null_ThrowsCorrectly()
+        {
+            _ = MatchedTripReport.GetMatchCounts(null);
+        }
+
+        [TestMethod]
+        public void GetMatchCounts_EmptyList_ReturnsZero()
+        {
+            int result = MatchedTripReport.GetMatchCounts(new());
+            Assert.AreEqual(0, result);
+        }
+
+        #endregion
     }
 }

--- a/TrailBot.Tests/MatchedTripReportTests.cs
+++ b/TrailBot.Tests/MatchedTripReportTests.cs
@@ -213,6 +213,46 @@ namespace CascadePass.TrailBot.Tests
             Assert.AreEqual(0, result);
         }
 
+        [TestMethod]
+        public void GetMatchCounts_SimpleCaseIsCorrect()
+        {
+            List<MatchInfo> matches = new();
+
+            Dictionary<string, int> termCounts = new();
+            Topic topic = new();
+            MatchInfo matchInfo = new() { MatchCounts = termCounts, Topic = topic };
+
+            termCounts.Add("test", 3);
+            matches.Add(matchInfo);
+
+            int result = MatchedTripReport.GetMatchCounts(matches);
+            Assert.AreEqual(3, result);
+        }
+
+        [TestMethod]
+        public void GetMatchCounts_OneTermMultipleTopics()
+        {
+            List<MatchInfo> matches = new();
+
+            Dictionary<string, int> termCounts1 = new(), termCounts2 = new(), termCounts3 = new();
+            Topic t1 = new(), t2 = new(), t3 = new();
+            MatchInfo
+                m1 = new() { MatchCounts = termCounts1, Topic = t1 },
+                m2 = new() { MatchCounts = termCounts2, Topic = t2 },
+                m3 = new() { MatchCounts = termCounts3, Topic = t3 };
+
+            termCounts1.Add("test", 1);
+            termCounts2.Add("test", 2);
+            termCounts3.Add("test", 3);
+
+            matches.Add(m1);
+            matches.Add(m2);
+            matches.Add(m3);
+
+            int result = MatchedTripReport.GetMatchCounts(matches);
+            Assert.AreEqual(6, result);
+        }
+
         #endregion
     }
 }

--- a/TrailBot/MatchedTripReport.cs
+++ b/TrailBot/MatchedTripReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace CascadePass.TrailBot
 {
@@ -79,6 +80,7 @@ namespace CascadePass.TrailBot
                 Region = (tripReport as WtaTripReport)?.Region,
                 TripDate = tripReport.TripDate,
                 WordCount = matches[0].WordCount,
+                MatchingTermCount = MatchedTripReport.GetMatchCounts(matches),
                 HikeType = (tripReport as WtaTripReport)?.HikeType,
                 BroaderContext = MatchedTripReport.GetExerpts(matches),
                 Topics = matches.Where(m => !m.IsEmpty).Select(m => m.Topic.Name).ToList(),
@@ -139,6 +141,18 @@ namespace CascadePass.TrailBot
             }
 
             return exerpts.ToString().Trim();
+        }
+
+        public static int GetMatchCounts(List<MatchInfo> matchInfos)
+        {
+            if (matchInfos is null)
+            {
+                throw new ArgumentNullException(nameof(matchInfos));
+            }
+
+            Dictionary<string, int> consolidated = MatchedTripReport.ConsolidateMatches(matchInfos);
+            int sum = consolidated.Sum(m => m.Value);
+            return sum;
         }
 
         private static Dictionary<string, int> ConsolidateMatches(List<MatchInfo> matchInfos)


### PR DESCRIPTION
Calculate the number of matching terms that caused a trip report to match one or more topics.  This is counted globally, for all topics.

![image](https://github.com/CascadePass/TrailBot/assets/106619481/db4514a7-f18e-4e4a-b916-e09c80333707)
