### PR TITLE
Fix rare crash while getting memory info

### DIFF
--- a/TrailBot.UI/UIcore/StatusStripViewModel.cs
+++ b/TrailBot.UI/UIcore/StatusStripViewModel.cs
@@ -25,7 +25,8 @@ namespace CascadePass.TrailBot.UI
             t.Start();
         }
 
-        public double SelectedFontSize {
+        public double SelectedFontSize
+        {
             get => (double)this.Resources["Font.Normal"];
             set
             {
@@ -116,12 +117,22 @@ namespace CascadePass.TrailBot.UI
         {
             get
             {
-                //return GC.GetTotalMemory(false).ToString("#,##0");
+                if (!this.ShowMemoryInfo)
+                {
+                    return string.Empty;
+                }
 
-                using var currentProcess = Process.GetCurrentProcess();
-                currentProcess.Refresh();
+                try
+                {
+                    using var currentProcess = Process.GetCurrentProcess();
+                    currentProcess.Refresh();
 
-                return currentProcess.PrivateMemorySize64.ToString("#,##0");
+                    return currentProcess.PrivateMemorySize64.ToString("#,##0");
+                }
+                catch (InvalidOperationException)
+                {
+                    return string.Empty;
+                }
             }
         }
 


### PR DESCRIPTION
Possibly during low memory conditions (?) the call to Process.PrivateMemorySize64 can throw an InvalidOperationException.  Update the code (1) to catch this exception rather than crashing, and (2) to not even ask if the application isn't in debug mode.

Plus make code formatting universal throughout document.