### PR TITLE
Handle 404s

### DIFF
--- a/TrailBot/WebDataProvider.cs
+++ b/TrailBot/WebDataProvider.cs
@@ -19,6 +19,7 @@ namespace CascadePass.TrailBot
         {
             this.PendingUrls = new();
             this.CompletedUrls = new();
+            this.ErrorUrls = new();
             this.Statistics = new();
         }
 
@@ -41,6 +42,8 @@ namespace CascadePass.TrailBot
         public List<string> PendingUrls { get; set; }
 
         public List<string> CompletedUrls { get; set; }
+
+        public List<string> ErrorUrls { get; set; }
 
         [XmlAttribute]
         public virtual int MinimumSleep

--- a/TrailBot/WtaDataProvider.cs
+++ b/TrailBot/WtaDataProvider.cs
@@ -59,6 +59,12 @@ namespace CascadePass.TrailBot
             webDriver.Navigate().GoToUrl(uri);
             this.LastTripReportRequest = DateTime.Now;
 
+            if (WtaDataProvider.IsPageNotFound(webDriver))
+            {
+                this.ErrorUrls.Add(uri.ToString());
+                return null;
+            }
+
             WtaTripReport report = this.ParseTripReport(webDriver, uri);
 
             this.OnTripReportCompleted(this, new TripReportCompletedEventArgs() { TripReport = report });
@@ -217,6 +223,25 @@ namespace CascadePass.TrailBot
             report.Snow = this.FindHikeCondition(report, "SNOW");
 
             return report;
+        }
+
+        public static bool IsPageNotFound(IWebDriver webDriver)
+        {
+            try
+            {
+                IWebElement reportBody = webDriver.FindElement(By.ClassName("documentFirstHeading"));
+
+                if (reportBody.Text.Contains("does not seem to exist"))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            catch (NoSuchElementException)
+            {
+                return false;
+            }
         }
 
         private string ParseReportText(IWebDriver webDriver)


### PR DESCRIPTION
When a trip report used to exist at the time when TrailBot read the "Latest Trip Reports" page, but has since been taken down and is no longer available when TrailBot is gets to that point in its to do list, it would see that page as an error and try again later.  Next time, it would still look like an error to TrailBot, who would put it at the end of the list and try again and again, and again.  This update allows TrailBot to understand the situation and stop asking for that url.