### PR TITLE
Preview Highlighting

### DIFF
--- a/TrailBot.Tests/Topic/TopicTests.cs
+++ b/TrailBot.Tests/Topic/TopicTests.cs
@@ -152,6 +152,22 @@ namespace CascadePass.TrailBot.Tests
             Assert.AreEqual(1, result.Count);
         }
 
+        [TestMethod]
+        public void ParseSearchTerms_ApostropheIsPartOfWord()
+        {
+            var result = Topic.ParseSearchTerms("occam's razor");
+
+            // 1 term (one line, terms are separated by line, this method was intended for parsing Match terms)
+            Assert.AreEqual(1, result.Count);
+
+            // 1 term has 2 keywords
+            // If the ' is not handled correctly, there will be 3 words:  occam s razor
+            Assert.AreEqual(2, result[0].Parts.Length);
+
+            Assert.AreEqual(result[0].Parts[0].Text, "occam's");
+            Assert.AreEqual(result[0].Parts[1].Text, "razor");
+        }
+
         #endregion
 
         #region Count Properties
@@ -184,6 +200,17 @@ namespace CascadePass.TrailBot.Tests
         }
 
         [TestMethod]
+        public void AnyCount_AgreesWith_MatchAnyPhrases()
+        {
+            Topic topic = new()
+            {
+                MatchAny = "one phrase\rper\n\r\n\r\nline",
+            };
+
+            Assert.AreEqual(topic.MatchAnyPhrases.Count, topic.AnyCount);
+        }
+
+        [TestMethod]
         public void UnlessCount_CountsLines()
         {
             Topic topic = new()
@@ -192,6 +219,17 @@ namespace CascadePass.TrailBot.Tests
             };
 
             Assert.AreEqual(3, topic.UnlessCount);
+        }
+
+        [TestMethod]
+        public void UnlessCount_AgreesWith_MatchAnyUnlessPhrases()
+        {
+            Topic topic = new()
+            {
+                MatchAnyUnless = "one phrase\rper\n\r\n\r\nline",
+            };
+
+            Assert.AreEqual(topic.MatchAnyUnlessPhrases.Count, topic.UnlessCount);
         }
 
         #endregion
@@ -252,6 +290,34 @@ namespace CascadePass.TrailBot.Tests
             Topic topic = new();
             MatchInfo result = topic.GetMatchInfo("   ");
             Assert.IsTrue(result.IsEmpty);
+        }
+
+        #endregion
+
+        #region ToString
+
+        [TestMethod]
+        public void ToString_Returns_Name()
+        {
+            Topic topic = new()
+            {
+                Name = "crime",
+                MatchAny = "broken\r\nwindow",
+            };
+
+            Assert.AreEqual(topic.Name, topic.ToString());
+        }
+
+        [TestMethod]
+        public void ToString_NoName_Returns_ClassName()
+        {
+            Topic topic = new()
+            {
+                MatchAny = "broken\r\nwindow",
+            };
+
+            Console.WriteLine(topic.ToString());
+            Assert.IsTrue(topic.ToString().Contains(typeof(Topic).FullName));
         }
 
         #endregion

--- a/TrailBot.Tests/Topic/TopicTests.cs
+++ b/TrailBot.Tests/Topic/TopicTests.cs
@@ -54,14 +54,23 @@ namespace CascadePass.TrailBot.Tests
         public void GetMatchInfo_NullTripReportDoesntThrow()
         {
             Topic t = new();
-            _ = t.GetMatchInfo(null);
+            _ = t.GetMatchInfo((TripReport)null);
         }
 
         [TestMethod]
         public void GetMatchInfo_NullTripReportNotAMatch()
         {
             Topic t = new();
-            var result = t.GetMatchInfo(null);
+            var result = t.GetMatchInfo((TripReport)null);
+
+            Assert.IsTrue(result == null || result.Count == 0);
+        }
+
+        [TestMethod]
+        public void GetMatchInfo_NullStringNotAMatch()
+        {
+            Topic t = new();
+            var result = t.GetMatchInfo((string)null);
 
             Assert.IsTrue(result == null || result.Count == 0);
         }
@@ -207,6 +216,42 @@ namespace CascadePass.TrailBot.Tests
             topic.MatchAnyUnless = testText;
 
             Assert.AreEqual(testText, topic.MatchAnyUnless);
+        }
+
+        #endregion
+
+        #region GetMatchInfo
+
+        [TestMethod]
+        public void GetMatchInfo_NullString()
+        {
+            Topic topic = new();
+            MatchInfo result = topic.GetMatchInfo((string)null);
+            Assert.IsTrue(result.IsEmpty);
+        }
+
+        [TestMethod]
+        public void GetMatchInfo_NullTripReport()
+        {
+            Topic topic = new();
+            MatchInfo result = topic.GetMatchInfo((TripReport)null);
+            Assert.IsTrue(result.IsEmpty);
+        }
+
+        [TestMethod]
+        public void GetMatchInfo_EmptyString()
+        {
+            Topic topic = new();
+            MatchInfo result = topic.GetMatchInfo(string.Empty);
+            Assert.IsTrue(result.IsEmpty);
+        }
+
+        [TestMethod]
+        public void GetMatchInfo_WhiteSpace()
+        {
+            Topic topic = new();
+            MatchInfo result = topic.GetMatchInfo("   ");
+            Assert.IsTrue(result.IsEmpty);
         }
 
         #endregion

--- a/TrailBot.UI.Tests/MatchedTripReportViewModelTests.cs
+++ b/TrailBot.UI.Tests/MatchedTripReportViewModelTests.cs
@@ -1,0 +1,233 @@
+﻿using CascadePass.TrailBot.UI.Feature.Found;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+
+namespace CascadePass.TrailBot.UI.Tests
+{
+    [TestClass]
+    public class MatchedTripReportViewModelTests
+    {
+        [TestMethod]
+        public void CanCreateInstance()
+        {
+            MatchedTripReportViewModel vm = new();
+        }
+
+        #region HasSelectedText
+
+        [TestMethod]
+        public void HasSelectedText_False()
+        {
+            MatchedTripReportViewModel vm = new() { SelectedPreviewText = null };
+            Assert.IsFalse(vm.HasSelectedText);
+        }
+
+        [TestMethod]
+        public void HasSelectedText_True()
+        {
+            MatchedTripReportViewModel vm = new() { SelectedPreviewText = Guid.NewGuid().ToString() };
+            Assert.IsTrue(vm.HasSelectedText);
+        }
+
+        #endregion
+
+        #region FontWeight
+
+        [TestMethod]
+        public void FontWeight_HasBeenSeen()
+        {
+            MatchedTripReportViewModel vm = new() { MatchedTripReport = new(), HasBeenSeen = true };
+            Assert.AreEqual(vm.FontWeight, FontWeights.Normal);
+        }
+
+        [TestMethod]
+        public void FontWeight_HasNotBeenSeen()
+        {
+            MatchedTripReportViewModel vm = new() { MatchedTripReport = new(), HasBeenSeen = false };
+            Assert.AreEqual(vm.FontWeight, FontWeights.DemiBold);
+        }
+
+        #endregion
+
+        #region PreviewDocument
+
+        [TestMethod]
+        public void PreviewDocument_NoTripReport()
+        {
+            MatchedTripReportViewModel vm = new() { Report = null };
+            Assert.IsNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_EmptyString()
+        {
+            MatchedTripReportViewModel vm = new() { Report = new() { ReportText = string.Empty } };
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_Guid()
+        {
+            MatchedTripReportViewModel vm = new() {
+                AllTopics = new(),
+                Report = new() {
+                    ReportText = Guid.NewGuid().ToString()
+                }
+            };
+
+            Assert.IsNotNull(vm.PreviewDocument);
+
+            // Gibberish input should not crash the UI
+        }
+
+        [TestMethod]
+        public void PreviewDocument_IsCached()
+        {
+            MatchedTripReportViewModel vm = new()
+            {
+                AllTopics = new(),
+                Report = new()
+                {
+                    ReportText = "broke my passenger side window"
+                }
+            };
+
+            object originalValue = vm.PreviewDocument;
+            Assert.AreSame(originalValue, vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_PhraseNoPunctuation()
+        {
+            MatchedTripReportViewModel vm = new() {
+                AllTopics = new(),
+                Report = new() {
+                    ReportText = "broke my passenger side window"
+                }
+            };
+
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_OneSentence()
+        {
+            MatchedTripReportViewModel vm = new()
+            {
+                AllTopics = new(),
+                Report = new()
+                {
+                    ReportText = "Somebody broke my passenger side window while I was hiking."
+                }
+            };
+
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_TwoSentences()
+        {
+            MatchedTripReportViewModel vm = new()
+            {
+                AllTopics = new(),
+                Report = new()
+                {
+                    ReportText = "Somebody broke my passenger side window while I was hiking.  I should have looked out for prowlers."
+                }
+            };
+
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_TwoParagraphs()
+        {
+            MatchedTripReportViewModel vm = new()
+            {
+                AllTopics = new(),
+                Report = new()
+                {
+                    ReportText = "Somebody broke my passenger side window while I was hiking.  I should have looked out for prowlers.\r\n\r\nIf you hike here, don't leave anything in your car."
+                }
+            };
+
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        [TestMethod]
+        public void PreviewDocument_TripReport_TwoParagraphs_MatchingTopics()
+        {
+            MatchedTripReportViewModel vm = new()
+            {
+                AllTopics = new(),
+                Report = new()
+                {
+                    ReportText = "Somebody broke my passenger side window while I was hiking.  I should have looked out for prowlers.\r\n\r\nIf you hike here, don't leave anything in your car."
+                }
+            };
+
+            vm.AllTopics.Add(new() { Name = "Crime", MatchAny = "broke\r\nwindow" });
+
+            Assert.IsNotNull(vm.PreviewDocument);
+        }
+
+        #endregion
+
+        #region Commands
+
+        [TestMethod]
+        public void ViewInBrowserCommand_NotNull()
+        {
+            MatchedTripReportViewModel vm = new();
+            Assert.IsNotNull(vm.ViewInBrowserCommand);
+        }
+
+        [TestMethod]
+        public void AddTextToTopicCommand_NotNull()
+        {
+            MatchedTripReportViewModel vm = new();
+            Assert.IsNotNull(vm.AddTextToTopicCommand);
+        }
+
+        [TestMethod]
+        public void AddExceptionTextToTopicCommand_NotNull()
+        {
+            MatchedTripReportViewModel vm = new();
+            Assert.IsNotNull(vm.AddExceptionTextToTopicCommand);
+        }
+
+        [TestMethod]
+        public void CreateTopicCommand_NotNull()
+        {
+            MatchedTripReportViewModel vm = new();
+            Assert.IsNotNull(vm.CreateTopicCommand);
+        }
+
+        [TestMethod]
+        public void CopySelectedTextCommand_NotNull()
+        {
+            MatchedTripReportViewModel vm = new();
+            Assert.IsNotNull(vm.CopySelectedTextCommand);
+        }
+
+        [TestMethod]
+        public void AllCommandsAreUnique()
+        {
+            MatchedTripReportViewModel vm = new();
+            HashSet<ICommand> commands = new();
+
+            commands.Add(vm.ViewInBrowserCommand);
+            commands.Add(vm.AddTextToTopicCommand);
+            commands.Add(vm.AddExceptionTextToTopicCommand);
+            commands.Add(vm.CreateTopicCommand);
+            commands.Add(vm.CopySelectedTextCommand);
+
+            // The purpose of this test is to catch copy/paste errors in property definitions
+        }
+        
+        #endregion
+    }
+}

--- a/TrailBot.UI.Tests/TrailBot.UI.Tests.csproj
+++ b/TrailBot.UI.Tests/TrailBot.UI.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ApplicationDataTests.cs" />
     <Compile Include="AppTests.cs" />
     <Compile Include="Dialogs\AddTermToTopic\AddTermToTopicViewModelTests.cs" />
+    <Compile Include="MatchedTripReportViewModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReverseBooleanToBooleanConverterTests.cs" />
     <Compile Include="ReverseBooleanToVisibilityConverterTests.cs" />

--- a/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
+++ b/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
@@ -1,6 +1,9 @@
-﻿using CascadePass.TrailBot.UI.Dialogs.AddTermToTopic;
+﻿using CascadePass.TrailBot.TextAnalysis;
+using CascadePass.TrailBot.UI.Dialogs.AddTermToTopic;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -19,16 +22,6 @@ namespace CascadePass.TrailBot.UI.Feature.Found
 
         public MatchedTripReport MatchedTripReport { get; set; }
 
-        //public string SourceUri { get; set; }
-
-        //public DateTime TripDate { get; set; }
-
-        //public string Title { get; set; }
-
-        //public string HikeType { get; set; }
-
-        //public string Region { get; set; }
-
         [XmlIgnore]
         public TripReport Report {
             get => this.tripReport;
@@ -43,12 +36,6 @@ namespace CascadePass.TrailBot.UI.Feature.Found
             }
         }
 
-        //public string Matches { get; set; }
-
-        //public string Filename { get; set; }
-
-        //public int WordCount { get; set; }
-
         public bool HasBeenSeen { 
             get => this.MatchedTripReport.HasBeenSeen;
             set
@@ -61,10 +48,6 @@ namespace CascadePass.TrailBot.UI.Feature.Found
                 }
             }
         }
-
-        //public string BroaderContext { get; set; }
-
-        //public List<string> Topics { get; set; }
 
         public FontWeight FontWeight => this.HasBeenSeen ? FontWeights.Normal : FontWeights.SemiBold;
 
@@ -83,6 +66,10 @@ namespace CascadePass.TrailBot.UI.Feature.Found
 
         public bool HasSelectedText => !string.IsNullOrWhiteSpace(this.SelectedPreviewText);
 
+        public List<Topic> AllTopics { get; set; }
+
+        public Settings Settings { get; set; }
+
         public FlowDocument PreviewDocument
         {
             get
@@ -91,8 +78,8 @@ namespace CascadePass.TrailBot.UI.Feature.Found
                 {
                     return null;
                 }
-                
-                return this.previewDocument ??= this.FormatFlowDocument(this.CreateFlowDocument(this.Report));
+
+                return this.previewDocument ??= this.CreateFlowDocument(this.Report);
             }
         }
 
@@ -155,9 +142,8 @@ namespace CascadePass.TrailBot.UI.Feature.Found
             viewModel.Window = hostWindow;
 
 
-            //TODO: Make a local property don't use this globally
-            viewModel.Settings = ApplicationData.Settings;
-            viewModel.Topics = ApplicationData.WebProviderManager.Topics;
+            viewModel.Settings = this.Settings;
+            viewModel.Topics = this.AllTopics;
 
 
             viewModel.Topic = topic;
@@ -169,111 +155,113 @@ namespace CascadePass.TrailBot.UI.Feature.Found
             {
                 if (mode == AddTermMode.CreateNewTopic)
                 {
-                    ApplicationData.WebProviderManager.Topics.Add(topic);
+                    this.AllTopics.Add(topic);
                 }
-                // redraw the preview
+                
+                //TODO: redraw the preview
             }
         }
 
         #region Preview Flow Document
 
-        private FlowDocument CreateFlowDocument(TripReport tripReportSource)
+        public FlowDocument CreateFlowDocument(TripReport tripReportSource)
         {
             var document = new FlowDocument() { PagePadding = new Thickness(5) };
             document.SetResourceReference(FlowDocument.FontSizeProperty, "Font.Large");
 
             string[] paragraphs = tripReportSource.ReportText.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
 
-            var titleRun = new Run($"{tripReportSource.Title} ({tripReportSource.TripDate.ToShortDateString()})");
-            var titleLink = new Hyperlink(titleRun) { Command = this.ViewInBrowserCommand };
-            var titleParagraph = new Paragraph(titleLink) { Margin = new Thickness(0, 0, 0, 10), FontWeight = FontWeights.ExtraBold };
-            titleRun.SetResourceReference(FlowDocument.FontSizeProperty, "Font.Huger");
-            document.Blocks.Add(titleParagraph);
-
+            document.Blocks.Add(this.CreatePreviewDocumentTitle(tripReportSource));            
 
             foreach (string paraText in paragraphs)
             {
-                var run = new Run(paraText) { Foreground = Brushes.DarkSlateGray };
-                var flowParagraph = new Paragraph(run) { Margin = new Thickness(0, 0, 0, 15) };
-
-                document.Blocks.Add(flowParagraph);
+                document.Blocks.Add(this.CreatePreviewDocumentParagraph(paraText));
             }
 
             return document;
         }
 
-        private FlowDocument FormatFlowDocument(FlowDocument document)
+        public Paragraph CreatePreviewDocumentTitle(TripReport tripReportSource)
         {
-            TextPointer currentPosition = document.ContentStart;
-            char[] punctuation = Topic.ClauseBoundaries;
+            var titleRun = new Run($"{tripReportSource.Title} ({tripReportSource.TripDate.ToShortDateString()})");
+            var titleLink = new Hyperlink(titleRun) { Command = this.ViewInBrowserCommand };
+            var titleParagraph = new Paragraph(titleLink) { Margin = new Thickness(0, 0, 0, 10), FontWeight = FontWeights.ExtraBold };
 
+            titleRun.SetResourceReference(FlowDocument.FontSizeProperty, "Font.Huger");
 
-            while (currentPosition != null)
+            return titleParagraph;
+        }
+
+        public Paragraph CreatePreviewDocumentParagraph(string paraText)
+        {
+            var flowParagraph = new Paragraph() { Margin = new Thickness(0, 0, 0, 15), Foreground = Brushes.DarkSlateGray };
+
+            foreach (string sentence in Regex.Split(paraText, "(?<=[.!?])"))
             {
-                if (currentPosition.CompareTo(document.ContentEnd) == 0)
-                {
-                    break;
-                }
+                this.CreatePreviewDocumentSentence(sentence, flowParagraph);
+            }
 
-                if (currentPosition.GetPointerContext(LogicalDirection.Forward) == TextPointerContext.Text)
+            return flowParagraph;
+        }
+
+        public void CreatePreviewDocumentSentence(string sentence, Paragraph flowParagraph)
+        {
+            bool isMatch = false;
+
+            if (this.AllTopics != null)
+            {
+                foreach (Topic topic in this.AllTopics)
                 {
-                    foreach (var wordCount in this.MatchedTripReport.Matches.Split(','))
+                    if (!topic.GetMatchInfo(sentence).IsEmpty)
                     {
-                        string textInCurrentRun = currentPosition.GetTextInRun(LogicalDirection.Forward);
-
-                        string compareText = textInCurrentRun.ToLower();
-                        if (compareText.Contains(wordCount))
-                        {
-                            int wordStartIndex = compareText.IndexOf(wordCount);
-                            int previousSentenceEnd = 0;
-
-                            for (int i = wordStartIndex; i >= 0; i--)
-                            {
-                                if (punctuation.Contains(compareText[i]))
-                                {
-                                    previousSentenceEnd = i + 1;
-                                    break;
-                                }
-                            }
-
-                            int curentSentenceEnd = compareText.IndexOfAny(punctuation, wordStartIndex);
-
-                            int offset = 0;
-                            if (previousSentenceEnd > 0 && curentSentenceEnd > 0)
-                            {
-                                TextPointer
-                                    sentenceStart = currentPosition.GetPositionAtOffset(previousSentenceEnd),
-                                    sentenceEnd = currentPosition.GetPositionAtOffset(curentSentenceEnd);
-
-                                offset = 3;
-                                var sentenceRange = new TextRange(sentenceStart, sentenceEnd);
-
-                                sentenceRange.ApplyPropertyValue(TextElement.ForegroundProperty, Brushes.Black);
-                                sentenceRange.ApplyPropertyValue(TextElement.FontWeightProperty, FontWeights.Medium);
-                                sentenceRange.ApplyPropertyValue(TextElement.BackgroundProperty, Brushes.Yellow);
-                            }
-
-                            TextPointer
-                                start = currentPosition.GetPositionAtOffset(offset + wordStartIndex),
-                                end = currentPosition.GetPositionAtOffset(offset + wordStartIndex + wordCount.Length)
-                                ;
-
-                            var colorRange = new TextRange(start, end);
-
-                            colorRange.ApplyPropertyValue(TextElement.ForegroundProperty, Brushes.Red);
-                            colorRange.ApplyPropertyValue(TextElement.FontWeightProperty, FontWeights.Bold);
-                        }
+                        isMatch = true;
+                        break;
                     }
-
-                    currentPosition = currentPosition.GetNextContextPosition(LogicalDirection.Forward);
-                }
-                else
-                {
-                    currentPosition = currentPosition.GetNextContextPosition(LogicalDirection.Forward);
                 }
             }
 
-            return document;
+            if (!isMatch)
+            {
+                var run = new Run(sentence.Trim() + " ") { Foreground = Brushes.DarkSlateGray };
+
+                flowParagraph.Inlines.Add(run);
+
+                return;
+            }
+
+            Tokenizer tokenizer = new();
+            tokenizer.GetTokens(sentence);
+
+            for (int i = 0; i < tokenizer.OrderedTokens.Count; i++)
+            {
+                bool found = false;
+
+                foreach (Topic topic in this.AllTopics)
+                {
+                    foreach (Phrase topicPhrase in topic.MatchAnyPhrases)
+                    {
+                        if (tokenizer.IsMatchAt(topicPhrase, i))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+
+                string following = i < tokenizer.OrderedTokens.Count - 1 && tokenizer.OrderedTokens[i + 1].IsWord ? " " : string.Empty;
+                if (found)
+                {
+                    var wordRun = new Run(tokenizer.OrderedTokens[i].Text) { Background = Brushes.Yellow, FontWeight = FontWeights.Bold, Foreground = Brushes.Black };
+                    flowParagraph.Inlines.Add(wordRun);
+                    flowParagraph.Inlines.Add(new Run(following) { Background = Brushes.Yellow });
+                }
+                else
+                {
+                    flowParagraph.Inlines.Add(new Run(tokenizer.OrderedTokens[i].Text + following) { Background = Brushes.Yellow });
+                }
+            }
+
+            flowParagraph.Inlines.Add(new Run(" "));
         }
 
         #endregion

--- a/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
+++ b/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
@@ -264,7 +264,7 @@ namespace CascadePass.TrailBot.UI.Feature.Found
                     }
                 }
 
-                string nextChar = i < tokenizer.OrderedTokens.Count - 1 && tokenizer.OrderedTokens[i + 1].IsWord ? " " : string.Empty;
+                string nextChar = i < tokenizer.OrderedTokens.Count - 1 && !tokenizer.OrderedTokens[i + 1].IsPunctuation ? " " : string.Empty;
 
                 var wordRun = new Run(tokenizer.OrderedTokens[i].Text + nextChar) { Background = Brushes.Yellow };
 

--- a/TrailBot.UI/Feature/Found/ReaderViewModel.cs
+++ b/TrailBot.UI/Feature/Found/ReaderViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Data;
 
 namespace CascadePass.TrailBot.UI.Feature.Found
@@ -97,15 +98,24 @@ namespace CascadePass.TrailBot.UI.Feature.Found
                 {
                     foreach (var item in this.webProviderManager.Found)
                     {
-                        this.MatchedTripReports.Add(new MatchedTripReportViewModel() { MatchedTripReport = item });
+                        this.MatchedTripReports.Add(ReaderViewModel.CreateMatchedViewModel(item));
                     }
                 }
             }
         }
 
+        public static MatchedTripReportViewModel CreateMatchedViewModel(MatchedTripReport item)
+        {
+            return new() {
+                MatchedTripReport = item,
+                AllTopics = ApplicationData.WebProviderManager.Topics,
+                Settings = ApplicationData.Settings,
+            };
+        }
+
         private void WebProviderManager_FoundMatch(object sender, MatchingTripReportEventArgs e)
         {
-            this.MatchedTripReports.Add(new() { MatchedTripReport = e.MatchedTripReport });
+            this.MatchedTripReports.Add(ReaderViewModel.CreateMatchedViewModel(e.MatchedTripReport));
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/TrailBot/Topic.cs
+++ b/TrailBot/Topic.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace CascadePass.TrailBot
 {
@@ -72,7 +71,7 @@ namespace CascadePass.TrailBot
                     Tokenizer tokenizer = new();
                     tokenizer.GetTokens(line);
 
-                    Phrase phrase = new Phrase(tokenizer.OrderedTokens.ToArray());
+                    Phrase phrase = new(tokenizer.OrderedTokens.ToArray());
 
                     if (!string.IsNullOrWhiteSpace(phrase.Text))
                     {

--- a/TrailBot/Topic.cs
+++ b/TrailBot/Topic.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace CascadePass.TrailBot
 {
@@ -35,6 +36,9 @@ namespace CascadePass.TrailBot
             }
         }
 
+        [XmlIgnore]
+        public List<Phrase> MatchAnyPhrases => this.anyPhrases;
+
         public string MatchAnyUnless
         {
             get => this.matchAnyUnless;
@@ -47,6 +51,9 @@ namespace CascadePass.TrailBot
                 }
             }
         }
+
+        [XmlIgnore]
+        public List<Phrase> MatchAnyUnlessPhrases => this.anyUnlessPhrases;
 
         #endregion
 
@@ -81,13 +88,23 @@ namespace CascadePass.TrailBot
         {
             if (tripReport == null)
             {
-                return null;
+                return new();
+            }
+
+            return this.GetMatchInfo(tripReport.GetSearchableReportText());
+        }
+
+        public MatchInfo GetMatchInfo(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return new();
             }
 
             int lastBreak = 0;
             MatchInfo found = new() { Topic = this };
             Tokenizer tokenizer = new();
-            tokenizer.GetTokens(tripReport.GetSearchableReportText());
+            tokenizer.GetTokens(text);
 
             found.WordCount = tokenizer.OrderedTokens.Count(m => m.IsWord);
 
@@ -186,6 +203,16 @@ namespace CascadePass.TrailBot
             }
 
             return found;
+        }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrWhiteSpace(this.Name))
+            {
+                return this.Name;
+            }
+
+            return base.ToString();
         }
     }
 }


### PR DESCRIPTION
Previously, the _Trip Report Preview_ was built in its entirety, then formatted in a second pass.  The UI was pretty naive about how it chose what text to highlight and bold.  The text formatting used a different algorithm than the text matching of trip reports, which was confusing and didn't inspire confidence.  A final, lesser issue is that the formatting was based on the topic list at the time TrailBot read the trip report, and would not update as the user refined their topics.

Now the document is built and formatted in one pass.  Each sentence is matched "live" against the topic list, instead of trying to find literal strings.  The text chosen for formatting is based on the same algorithm that TrailBot uses to decide whether a trip report matches a topic when it reads it.

![image](https://github.com/CascadePass/TrailBot/assets/106619481/7cdba9d6-eee1-47bf-891e-022b68fca5bd)

Multi word terms are handled properly:

![image](https://github.com/CascadePass/TrailBot/assets/106619481/79ef8595-8f2a-4577-9521-2c21459b9edf)
