### PR TITLE
Parse and record image links

### DIFF
--- a/TrailBot/WtaDataProvider.cs
+++ b/TrailBot/WtaDataProvider.cs
@@ -274,6 +274,7 @@ namespace CascadePass.TrailBot
             report.Trails = WtaDataProvider.ParseReportTrails(webDriver);
             report.TrailConditions = WtaDataProvider.ParseReportConditions(webDriver);
             report.Feature = WtaDataProvider.ParseReportFeature(webDriver);
+            report.ImageUrls = WtaDataProvider.ParseReportImages(webDriver);
 
             report.HikeType = WtaDataProvider.FindHikeType(report);
             report.RoadConditions = WtaDataProvider.FindRoadConditions(report);
@@ -524,6 +525,43 @@ namespace CascadePass.TrailBot
                 foreach (var ele in tripHighlights?.FindElements(By.ClassName("wta-icon")))
                 {
                     found.Add(ele.Text);
+                }
+            }
+            catch (NoSuchElementException)
+            {
+            }
+
+            return found;
+        }
+
+        public static List<string> ParseReportImages(IWebDriver webDriver)
+        {
+            #region Sanity check
+
+            if (webDriver == null)
+            {
+                return null;
+            }
+
+            #endregion
+
+            List<string> found = new();
+
+            try
+            {
+                IWebElement reportBody = webDriver.FindElement(By.Id("report-wrapper"));
+
+                foreach (var ele in reportBody?.FindElements(By.TagName("img")))
+                {
+                    string source = ele.GetAttribute("src");
+
+                    if (
+                        Uri.TryCreate(source, UriKind.Absolute, out Uri uri) &&
+                        source.Contains("/site_images/trip-reports/")
+                        )
+                    {
+                        found.Add(source);
+                    }
                 }
             }
             catch (NoSuchElementException)


### PR DESCRIPTION
Add a method to find image links that are part of the trip report and add them to the TR object's ImageUrls property.

![image](https://github.com/CascadePass/TrailBot/assets/106619481/5bc926ed-5a54-427a-836a-c50ea0e62a1b)