### PR TITLE
Improve matching

### DIFF
--- a/TrailBot.Tests/WtaTripReportTests.cs
+++ b/TrailBot.Tests/WtaTripReportTests.cs
@@ -103,12 +103,14 @@ namespace CascadePass.TrailBot.Tests
 
             string searchText = tripReport.GetSearchableReportText();
 
-            Assert.IsFalse(searchText.Contains(title));
-            Assert.IsTrue(searchText.Contains(body));
+            Console.WriteLine(searchText);
+
+            Assert.IsFalse(searchText.Contains(title), "The title was found in the search text, but should not be there.");
+            Assert.IsTrue(searchText.Contains(body), "The body was missing from the search text!");
         }
 
         [TestMethod]
-        public void FeatureContainedInSearchableText()
+        public void FeatureNotContainedInSearchableText()
         {
             string feature1 = Guid.NewGuid().ToString(), feature2 = Guid.NewGuid().ToString();
             WtaTripReport tripReport = new();
@@ -117,9 +119,10 @@ namespace CascadePass.TrailBot.Tests
             tripReport.Feature.Add(feature2);
 
             string searchText = tripReport.GetSearchableReportText();
+            Console.WriteLine(searchText);
 
-            Assert.IsTrue(searchText.Contains(feature1));
-            Assert.IsTrue(searchText.Contains(feature2));
+            Assert.IsFalse(searchText.Contains(feature1));
+            Assert.IsFalse(searchText.Contains(feature2));
         }
 
         [TestMethod]
@@ -139,7 +142,7 @@ namespace CascadePass.TrailBot.Tests
         }
 
         [TestMethod]
-        public void TrailConditionsContainedInSearchableText()
+        public void TrailConditionsNotContainedInSearchableText()
         {
             string feature1 = Guid.NewGuid().ToString(), feature2 = Guid.NewGuid().ToString();
 
@@ -149,9 +152,10 @@ namespace CascadePass.TrailBot.Tests
             tripReport.TrailConditions.Add(new WtaTrailCondition() { Title = "2", Description = feature2 });
 
             string searchText = tripReport.GetSearchableReportText();
+            Console.WriteLine(searchText);
 
-            Assert.IsTrue(searchText.Contains(feature1));
-            Assert.IsTrue(searchText.Contains(feature2));
+            Assert.IsFalse(searchText.Contains(feature1));
+            Assert.IsFalse(searchText.Contains(feature2));
         }
 
         [TestMethod]
@@ -183,12 +187,13 @@ namespace CascadePass.TrailBot.Tests
             tripReport.TrailConditions.Add(new WtaTrailCondition() { Title = label2, Description = feature2 });
 
             string searchText = tripReport.GetSearchableReportText();
+            Console.WriteLine(searchText);
 
-            Assert.IsFalse(searchText.Contains(label1));
-            Assert.IsFalse(searchText.Contains(label2));
+            Assert.IsFalse(searchText.Contains(label1), $"Search text contains label '{label1}'");
+            Assert.IsFalse(searchText.Contains(label2), $"Search text contains label '{label2}'");
 
-            Assert.IsTrue(searchText.Contains(feature1));
-            Assert.IsTrue(searchText.Contains(feature2));
+            Assert.IsFalse(searchText.Contains(feature1), $"Search text contains value '{feature1}'");
+            Assert.IsFalse(searchText.Contains(feature2), $"Search text contains value '{feature1}'");
         }
 
         #endregion

--- a/TrailBot/WtaTripReport.cs
+++ b/TrailBot/WtaTripReport.cs
@@ -116,22 +116,6 @@ namespace CascadePass.TrailBot
         {
             StringBuilder stringBuilder = new();
 
-            foreach (string feature in this.Feature)
-            {
-                if (!string.IsNullOrEmpty(feature))
-                {
-                    stringBuilder.AppendLine(feature);
-                }
-            }
-
-            foreach (var condition in this.TrailConditions)
-            {
-                if (!string.IsNullOrEmpty(condition.Description))
-                {
-                    stringBuilder.AppendLine(condition.Description);
-                }
-            }
-
             if (!string.IsNullOrEmpty(this.ReportText))
             {
                 stringBuilder.AppendLine(this.ReportText);


### PR DESCRIPTION
Remove some fields from consideration when matching a trip report against the user's topics:

- Title
- Feature description
- Trail, Road, and Snow Conditions

These fields are not shown in the Trip Report Preview screen, leading to confusion.  It's not useful to match on trip reports that say "no snow," especially when the UI can't explain why this was matched.