### PR TITLE
Improve Tooltip in Found Trip Reports Grid

### DIFF
--- a/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
+++ b/TrailBot.UI/Feature/Found/MatchedTripReportViewModel.cs
@@ -117,6 +117,10 @@ namespace CascadePass.TrailBot.UI.Feature.Found
             }
         }
 
+
+        [XmlIgnore]
+        public Dictionary<string, string> FormattedExerpts { get; set; }
+
         public FlowDocument PreviewDocument
         {
             get

--- a/TrailBot.UI/Feature/Found/TripReportsView.xaml
+++ b/TrailBot.UI/Feature/Found/TripReportsView.xaml
@@ -40,7 +40,40 @@
                 <Style TargetType="{x:Type DataGridRow}">
                     <Setter Property="FontWeight" Value="{Binding FontWeight}" />
                     <Setter Property="ToolTipService.ShowOnDisabled" Value="True"/>
-                    <Setter Property="ToolTip" Value="{Binding MatchedTripReport.BroaderContext}" />
+                    <Setter Property="ToolTip">
+                        <Setter.Value>
+                            <Border BorderThickness="0.5" BorderBrush="Gray" CornerRadius="5" Padding="5,0,5,5" MaxWidth="600">
+                                <StackPanel>
+                                    <TextBlock FontSize="{DynamicResource Font.Huge}" FontWeight="Bold">
+                                        <Run Text="{Binding MatchedTripReport.Title}" />
+                                        <Run Text="{Binding MatchedTripReport.TripDate, StringFormat=d}" />
+                                    </TextBlock>
+
+                                    <TextBlock FontSize="{DynamicResource Font.Large}" FontWeight="SemiBold">
+                                        <Run Text="{Binding MatchedTripReport.HikeType}" />
+                                        <Run Text="-" />
+                                        <Run Text="{Binding MatchedTripReport.Region}" />
+                                    </TextBlock>
+
+                                    <TextBlock FontSize="{DynamicResource Font.Normal}" FontStyle="Italic" Foreground="Red" Text="{Binding MatchedTripReport.Matches}" />
+
+                                    <!--Blank line as separator-->
+                                    <TextBlock FontSize="{DynamicResource Font.Normal}" />
+
+                                    <ItemsControl ItemsSource="{Binding FormattedExerpts}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="{DynamicResource Font.Normal}" TextWrapping="Wrap">
+                                                    <Run FontWeight="Bold" Text="{Binding Key, Mode=OneWay}" />
+                                                    <Run FontWeight="Light" FontStyle="Italic" Foreground="Green" Text="{Binding Value, Mode=OneWay}" />
+                                                </TextBlock>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </Border>
+                        </Setter.Value>
+                    </Setter>
                 </Style>
             </DataGrid.Resources>
         </DataGrid>

--- a/TrailBot/MatchedTripReport.cs
+++ b/TrailBot/MatchedTripReport.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml.Serialization;
 
 namespace CascadePass.TrailBot
 {


### PR DESCRIPTION
Use a much better design for clarity and visual attractiveness.

- Tooltips now include the trip report title and other info, so users know what the TT relates to
- Keywords and excerpts are color coded and italic, to help the user recognize them at a glance (and see whether the trip report is worth reading in full)
- Bold is used to draw attention to topic labels proceeding the excerpt lists

### Before
![image](https://github.com/CascadePass/TrailBot/assets/106619481/3cd56ee8-a3eb-4143-9b54-e2e222ec435f)

### After
![image](https://github.com/CascadePass/TrailBot/assets/106619481/4578ffe7-d2eb-45d0-92e6-25bfefc42065)
