### PR TITLE
Remove MatchText property

### DIFF
--- a/TrailBot.DataAccess.Tests/IntegrationTests/TopicTests.cs
+++ b/TrailBot.DataAccess.Tests/IntegrationTests/TopicTests.cs
@@ -181,7 +181,6 @@ namespace TrailBot.DataAccess.Tests.IntegrationTests
             {
                 ID = id,
                 Name = Guid.NewGuid().ToString(),
-                MatchText = matchText,
             };
         }
 

--- a/TrailBot.DataAccess/DTO/Topic.cs
+++ b/TrailBot.DataAccess/DTO/Topic.cs
@@ -7,7 +7,5 @@ namespace CascadePass.TrailBot.DataAccess.DTO
         public long ID { get; set; }
 
         public string Name { get; set; }
-
-        public List<TopicText> MatchText { get; set; }
     }
 }


### PR DESCRIPTION
Update integration tests to no longer use this property.

This was intended to be included in the previous pull request, Create Data Access Layer.