### PR TITLE
Make database filename a configurable setting

### DIFF
--- a/TrailBot.DataAccess.Tests/DatabaseTests.cs
+++ b/TrailBot.DataAccess.Tests/DatabaseTests.cs
@@ -50,6 +50,15 @@ namespace TrailBot.DataAccess.Tests
 
         #endregion
 
+        [TestMethod]
+        public void GetConnectionString_ValidFilename()
+        {
+            string result = Database.GetConnectionString("123.db");
+
+            Assert.IsTrue(result.Contains("123.db"));
+            Assert.IsTrue(result.Contains("Data Source="));
+        }
+
         #region Exceptions
 
         [TestMethod]

--- a/TrailBot.DataAccess/Database.cs
+++ b/TrailBot.DataAccess/Database.cs
@@ -33,6 +33,8 @@ namespace CascadePass.TrailBot.DataAccess
 
         #endregion
 
+        #region Data Manipulation
+
         #region Url
 
         public static long Add(Url url)
@@ -776,9 +778,16 @@ namespace CascadePass.TrailBot.DataAccess
 
         #endregion
 
+        #endregion
+
         #region ADO.NET abstraction methods
 
         #region Get Connection
+
+        public static string GetConnectionString(string sqliteDatabaseFilename)
+        {
+            return $"Data Source={sqliteDatabaseFilename}";
+        }
 
         /// <summary>
         /// Gets a connection to the database.

--- a/TrailBot.UI.Tests/AppTests.cs
+++ b/TrailBot.UI.Tests/AppTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
 
 namespace CascadePass.TrailBot.UI.Tests
 {
@@ -13,6 +15,50 @@ namespace CascadePass.TrailBot.UI.Tests
         public void CanCreateInstance()
         {
             _ = this.TestAppInstance;
+        }
+
+        [TestMethod]
+        public void RequireSetupScreen_False()
+        {
+            ApplicationData.Settings = new();
+            ApplicationData.WasSettingsMissing = false;
+            ApplicationData.Settings.SqliteDatabaseFilename = Directory.GetFiles(Environment.CurrentDirectory)[0];
+
+            Assert.IsFalse(App.RequireSetupScreen);
+        }
+
+        [TestMethod]
+        public void RequireSetupScreen_True_NoDatabaseFilename()
+        {
+            ApplicationData.Settings = new();
+            ApplicationData.WasSettingsMissing = false;
+            ApplicationData.Settings.SqliteDatabaseFilename = null;
+
+            Assert.IsTrue(App.RequireSetupScreen);
+        }
+
+        [TestMethod]
+        public void RequireSetupScreen_True_SettingsWereMissing()
+        {
+            ApplicationData.Settings = new();
+            ApplicationData.WasSettingsMissing = true;
+            ApplicationData.Settings.SqliteDatabaseFilename = null;
+
+            Assert.IsTrue(App.RequireSetupScreen);
+        }
+
+        [TestMethod]
+        public void RequireSetupScreen_NullSettings()
+        {
+            ApplicationData.Settings = null;
+
+            Assert.IsTrue(App.RequireSetupScreen);
+        }
+
+        [TestMethod]
+        public void GetSettings()
+        {
+            App.GetSettings();
         }
     }
 }

--- a/TrailBot.UI.Tests/SettingsTests.cs
+++ b/TrailBot.UI.Tests/SettingsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.ComponentModel;
 
 namespace CascadePass.TrailBot.UI.Tests
 {
@@ -55,6 +56,16 @@ namespace CascadePass.TrailBot.UI.Tests
         }
 
         [TestMethod]
+        public void SqliteDatabaseFilename_GetSetAccessSameValue()
+        {
+            string value = Guid.NewGuid().ToString();
+            Settings settings = new();
+
+            settings.SqliteDatabaseFilename = value;
+            Assert.IsTrue(string.Equals(settings.SqliteDatabaseFilename, value, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
         public void IndexFilename_GetSetAccessSameValue()
         {
             string value = Guid.NewGuid().ToString();
@@ -105,6 +116,34 @@ namespace CascadePass.TrailBot.UI.Tests
 
             settings.ShowPreviewPane = !settings.ShowPreviewPane;
             Assert.IsTrue(settings.IsDirty);
+        }
+
+        [TestMethod]
+        public void SqliteDatabaseFilename_Makes_IsDirty_True()
+        {
+            string value = Guid.NewGuid().ToString();
+            Settings settings = new();
+
+            settings.SqliteDatabaseFilename = value;
+            Assert.IsTrue(settings.IsDirty);
+        }
+
+        [TestMethod]
+        public void SqliteDatabaseFilename_IgnoresSameValue()
+        {
+            Assert.Inconclusive();
+            //string value = Guid.NewGuid().ToString();
+            //Settings settings = new();
+            //bool eventFired = false;
+
+            //PropertyChangedEventHandler handler = Delegate() => { eventFired = true; };
+
+            //settings.SqliteDatabaseFilename = value;
+
+            //settings.PropertyChanged += handler;
+            //settings.SqliteDatabaseFilename = value;
+
+            //Assert.IsTrue(eventFired);
         }
 
         [TestMethod]

--- a/TrailBot.UI/Settings.cs
+++ b/TrailBot.UI/Settings.cs
@@ -6,13 +6,27 @@ namespace CascadePass.TrailBot.UI
     [Serializable]
     public class Settings : ObservableObject
     {
-        private string xmlFolder, indexFilename;
+        private string sqliteDatabaseFilename, xmlFolder, indexFilename;
         private bool showPreviewPane, isDirty, debugMode, suggestAdditionalTerms;
 
         #region Properties
 
         [XmlIgnore]
         public bool IsDirty => this.isDirty;
+
+        public string SqliteDatabaseFilename
+        {
+            get => this.sqliteDatabaseFilename;
+            set
+            {
+                // File paths are case insensitive in Windows
+                if (!string.Equals(this.sqliteDatabaseFilename, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.sqliteDatabaseFilename = value;
+                    this.OnPropertyChanged(nameof(this.SqliteDatabaseFilename));
+                }
+            }
+        }
 
         public string IndexFilename
         {


### PR DESCRIPTION
Add a property to Settings, add a method to Database to turn a filename into a connection string, update the App class to load the settings and assign the connection string to the database, and to load the welcome/setup screen if it's not present.  Add tests as well for the new functionality.